### PR TITLE
fix: add translations folder in package data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,15 @@ Unreleased
 
 *
 
-0.2.0 – 2024-04-16
+0.2.1 - 2024-04-24
+**********************************************
+
+Changed
+=======
+
+* Add translations folder in package data.
+
+0.2.0 - 2024-04-16
 **********************************************
 
 Added
@@ -27,7 +35,7 @@ Added
 * Added Forward Nagivation Only setting.
 * Added Subset Size setting for randomization.
 
-0.1.0 – 2024-03-26
+0.1.0 - 2024-03-26
 **********************************************
 
 Added

--- a/controlled_navigation/__init__.py
+++ b/controlled_navigation/__init__.py
@@ -4,4 +4,4 @@ Init for the XblockControlledNavigation package.
 
 from .controlled_navigation import XBlockControlledNavigation
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/setup.py
+++ b/setup.py
@@ -194,5 +194,5 @@ setup(
             "controlled_navigation = controlled_navigation:XBlockControlledNavigation",
         ]
     },
-    package_data=package_data("controlled_navigation", ["static", "public"]),
+    package_data=package_data("controlled_navigation", ["static", "public", "translations"]),
 )


### PR DESCRIPTION
### Description
This PR adds the `translations` folder to package data, this will add the files that are inside this directory at the time of package installation.